### PR TITLE
Updates for handling parameters and retrieve domains by UUID or name

### DIFF
--- a/cmd/sushy-mock/main.go
+++ b/cmd/sushy-mock/main.go
@@ -1,10 +1,24 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/andfasano/tiny-sushy-tools/internal/redfish"
 )
 
 func main() {
+	var tiny_sushy_port string
+	var tiny_libvirt_user string
+	var tiny_libvirt_ip string
+	var tiny_libvirt_key string
+
+	flag.StringVar(&tiny_sushy_port, "port", "8000", "port to listen")
+	flag.StringVar(&tiny_libvirt_user, "user", "root", "user for libvirt connection")
+	flag.StringVar(&tiny_libvirt_ip, "ip", "192.168.1.13", "ip of libvirt server")
+	flag.StringVar(&tiny_libvirt_key, "keyfile", "~/.ssh/id_rsa", "path to ssh key for libvirt server")
+
+	flag.Parse()
+
 	server := redfish.New()
-	server.Start("8000")
+	server.Start(tiny_sushy_port, tiny_libvirt_user, tiny_libvirt_ip, tiny_libvirt_key)
 }

--- a/cmd/sushy-mock/main.go
+++ b/cmd/sushy-mock/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	flag.StringVar(&tiny_sushy_port, "port", "8000", "port to listen")
 	flag.StringVar(&tiny_libvirt_user, "user", "root", "user for libvirt connection")
-	flag.StringVar(&tiny_libvirt_ip, "ip", "192.168.1.13", "ip of libvirt server")
+	flag.StringVar(&tiny_libvirt_ip, "ip", "127.0.0.1", "ip of libvirt server")
 	flag.StringVar(&tiny_libvirt_key, "keyfile", "~/.ssh/id_rsa", "path to ssh key for libvirt server")
 
 	flag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/beevik/etree v1.1.0
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/libvirt/libvirt-go v6.7.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/andfasano/tiny-sushy-tools v0.0.0-20200902154749-f6499244d1e7 h1:9jPo/eTVea/FvoO0jdho5jIM5QiFqbx3rILLOR3XUtc=
+github.com/andfasano/tiny-sushy-tools v0.0.0-20200902154749-f6499244d1e7/go.mod h1:6tJoIUql355Qc6XdfG2Ar0eFRENH8Mk09yZD1MbiM60=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/libvirt/libvirt-go v6.7.0+incompatible h1:/XN/rOdToxgpdLiai/VEvz0JI8EJdlS/qxFvVNyk+sk=
 github.com/libvirt/libvirt-go v6.7.0+incompatible/go.mod h1:34zsnB4iGeOv7Byj6qotuW8Ya4v4Tr43ttjz/F0wjLE=
+github.com/libvirt/libvirt-go v7.4.0+incompatible h1:crnSLkwPqCdXtg6jib/FxBG/hweAc/3Wxth1AehCXL4=
+github.com/libvirt/libvirt-go v7.4.0+incompatible/go.mod h1:34zsnB4iGeOv7Byj6qotuW8Ya4v4Tr43ttjz/F0wjLE=

--- a/internal/redfish/libvirtdriver.go
+++ b/internal/redfish/libvirtdriver.go
@@ -49,8 +49,37 @@ type libvirtDomainFacade struct {
 	domain *libvirt.Domain
 }
 
+func Uri(user string, ip string, keyfilePath string, parameters string) (string, error) {
+	// concatenate everything
+	// Uri(user, ip, keyfile, parameters)
+	// default URI: "qemu+ssh://root@192.168.111.1/system?&keyfile=~/.ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
+	var lvUrl string
+
+	if user == "" {
+		user = "root"
+	}
+
+	if ip == "" {
+		ip = "192.168.111.1"
+	}
+
+	if keyfilePath == "" {
+		keyfilePath = "~/.ssh/id_rsa_virt_power"
+	}
+
+	if parameters == "" {
+		parameters = "&no_verify=1&no_tty=1"
+	}
+
+	lvUrl = "qemu+ssh://" + user + "@" + ip + "/system?&keyfile=" + keyfile + parameters
+
+	fmt.println("URI set to: " + lvUrl)
+
+	return lvUrl, nil
+}
+
 func newLibvirtDomain(UUID string) *libvirtDomainFacade {
-	conn, err := libvirt.NewConnect("qemu+ssh://root@192.168.111.1/system?&keyfile=~/.ssh/id_rsa_virt_power&no_verify=1&no_tty=1")
+	conn, err := libvirt.NewConnect(Uri("root", "192.168.111.1", "~/.ssh/id_rsa_virt_power"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/redfish/libvirtdriver.go
+++ b/internal/redfish/libvirtdriver.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/beevik/etree"
+	uuid "github.com/google/uuid"
 	libvirt "github.com/libvirt/libvirt-go"
 )
 
@@ -49,9 +50,7 @@ type libvirtDomainFacade struct {
 	domain *libvirt.Domain
 }
 
-func Uri(user string, ip string, keyfilePath string, parameters string) (string, error) {
-	// concatenate everything
-	// Uri(user, ip, keyfile, parameters)
+func Uri(user string, ip string, keyfilePath string) (string, error) {
 	// default URI: "qemu+ssh://root@192.168.111.1/system?&keyfile=~/.ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
 	var lvUrl string
 
@@ -67,26 +66,35 @@ func Uri(user string, ip string, keyfilePath string, parameters string) (string,
 		keyfilePath = "~/.ssh/id_rsa_virt_power"
 	}
 
-	if parameters == "" {
-		parameters = "&no_verify=1&no_tty=1"
-	}
-
-	lvUrl = "qemu+ssh://" + user + "@" + ip + "/system?&keyfile=" + keyfile + parameters
-
-	fmt.println("URI set to: " + lvUrl)
+	lvUrl = "qemu+ssh://" + user + "@" + ip + "/system?&keyfile=" + keyfilePath + "&no_verify=1&no_tty=1"
 
 	return lvUrl, nil
 }
 
+func isValidUUID(u string) bool {
+	_, err := uuid.Parse(u)
+	return err == nil
+}
+
 func newLibvirtDomain(UUID string) *libvirtDomainFacade {
-	conn, err := libvirt.NewConnect(Uri("root", "192.168.111.1", "~/.ssh/id_rsa_virt_power"))
+	var dom *libvirt.Domain
+
+	url, _ := Uri(TINY_LIBVIRT_USER, TINY_LIBVIRT_IP, TINY_LIBVIRT_KEY)
+	conn, err := libvirt.NewConnect(url)
 	if err != nil {
 		panic(err)
 	}
 
-	dom, err := conn.LookupDomainByUUIDString(UUID)
-	if err != nil {
-		panic(err)
+	if isValidUUID(UUID) {
+		dom, err = conn.LookupDomainByUUIDString(UUID)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		dom, err = conn.LookupDomainByName(UUID)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	facade := &libvirtDomainFacade{
@@ -107,6 +115,15 @@ func (l *libvirtDomainFacade) getName() string {
 		panic(err)
 	}
 	return name
+}
+
+func (l *libvirtDomainFacade) getUUID() string {
+	uuidBytes, err := l.domain.GetUUID()
+	if err != nil {
+		panic(err)
+	}
+	uuidstr, _ := uuid.FromBytes(uuidBytes)
+	return uuidstr.String()
 }
 
 func (l *libvirtDomainFacade) getPowerState() string {

--- a/internal/redfish/redfish.go
+++ b/internal/redfish/redfish.go
@@ -10,6 +10,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+var TINY_SUSHY_PORT string = "8000"
+var TINY_LIBVIRT_USER string = "root"
+var TINY_LIBVIRT_IP string = "192.168.1.13"
+var TINY_LIBVIRT_KEY string = "~/.ssh/id_rsa"
+
 //Server represents a mock server supporting partially the RedFish protocol
 type Server struct {
 	router *mux.Router
@@ -25,8 +30,14 @@ func New() *Server {
 }
 
 //Start initialize and kicks off the redfish server
-func (rf *Server) Start(port string) {
+func (rf *Server) Start(port string, user string, ip string, keyfile string) {
 	rf.router = mux.NewRouter()
+
+	//Define global variables
+	TINY_SUSHY_PORT = port
+	TINY_LIBVIRT_USER = user
+	TINY_LIBVIRT_IP = ip
+	TINY_LIBVIRT_KEY = keyfile
 
 	//RedFish protocol
 	rf.router.HandleFunc("/", rf.handleCatchAll)
@@ -171,6 +182,8 @@ func (rf *Server) handleSystemsByID(w http.ResponseWriter, r *http.Request) {
 
 func (rf *Server) handleSystems(w http.ResponseWriter, r *http.Request) {
 	rf.logRequest("/redfish/v1/Systems", r)
+	response := "Listing not allowed. Please specify system identity /redfish/v1/Systems/{identity}"
+	http.Error(w, response, http.StatusForbidden)
 }
 
 func (rf *Server) handleEntrypoint(w http.ResponseWriter, r *http.Request) {

--- a/internal/redfish/system.go
+++ b/internal/redfish/system.go
@@ -35,6 +35,7 @@ func newSystem(UUID string) *system {
 
 	lv := newLibvirtDomain(UUID)
 
+	s.UUID = lv.getUUID()
 	s.Name = lv.getName()
 	s.PowerState = lv.getPowerState()
 	s.BootSourceTarget = lv.getBootSourceTarget()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,9 @@
 # github.com/beevik/etree v1.1.0
 ## explicit
 github.com/beevik/etree
+# github.com/google/uuid v1.3.0
+## explicit
+github.com/google/uuid
 # github.com/gorilla/mux v1.8.0
 ## explicit
 github.com/gorilla/mux


### PR DESCRIPTION

Updates for handling parameters and retrieve domains by UUID or name 

- Added options for specifying `port` to run tiny-sushy-tools
- Added options for specifying libvirt server usernmae, IP and ssh key file to use
    ```bash
    Usage of ./tiny-sushy -h
    -ip string
            ip of libvirt server (default "192.168.1.13")
    -keyfile string
            path to ssh key for libvirt server (default "~/.ssh/id_rsa")
    -port string
            port to listen (default "8000")
    -user string
            user for libvirt connection (default "root")
    ```
- Added function to concatenate libvirt URI
- Added function to validate UUID 
- Added logic to find libvirt domain by uuid or name
- Added function to retrieve UUID from Domain object
- Updated `system.go` to properly identify UUID if Domain was retrieve by name