### PR TITLE
More refactoring for extensibility with drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,35 @@
 
 Very small (and not complete) Go porting of the original [sushy-tools project](https://github.com/openstack/sushy-tools) meant to support testing of the [Metal3 BareMetal Operator](https://github.com/metal3-io/baremetal-operator/)
 
-# Pre-requisites
+## Building the package
 
-Install the libvirt-dev package:
+- Pre-requisites for building the package: Install the libvirt-dev package
 
-```sudo yum install libvirt-devel libvirt-daemon-kvm libvirt-client```
+    ```bash
+    sudo dnf install libvirt-devel libvirt-daemon-kvm libvirt-client
+    ```
 
-(then start libvritd if required: ```sudo systemctl enable --now libvirtd```)
+- Make sure `libvirt` service is running in the backend server
+
+    ```bash
+    sudo systemctl enable --now libvirtd
+    ```
+
+- Compiling the code
+
+    ```bash
+    go build -o tiny-sushy cmd/sushy-mock/main.go
+    ```
+
+- Running the code. (Pre-requisite for user to have ssh-key authentication to the libvirt node)
+
+    ```bash
+    ./tiny-sushy -ip 192.168.1.10 -port 9000
+    2021/09/08 00:07:43 Starting RedFish mock server on port  9000
+    ```
+
+- `curl` queries for testing configuration
+
+    ```bash
+    curl http://localhost:9000/redfish/v1/Systems/<your-system-id>
+    ```

--- a/cmd/sushy-mock/main.go
+++ b/cmd/sushy-mock/main.go
@@ -10,6 +10,7 @@ func main() {
 	server := redfish.New()
 
 	flag.StringVar(&server.TinySushyPort, "port", "8000", "port to listen")
+	flag.StringVar(&server.TinySushyDriver, "driver", "libvirt", "backend driver to use (libvirt, execdriver, dummydriver)")
 	flag.StringVar(&server.TinyOobUser, "user", "root", "user for libvirt connection")
 	flag.StringVar(&server.TinyOobIP, "ip", "127.0.0.1", "ip of libvirt server")
 	flag.StringVar(&server.TinyOobKey, "keyfile", "~/.ssh/id_rsa", "path to ssh key for libvirt server")

--- a/cmd/sushy-mock/main.go
+++ b/cmd/sushy-mock/main.go
@@ -7,18 +7,14 @@ import (
 )
 
 func main() {
-	var tiny_sushy_port string
-	var tiny_libvirt_user string
-	var tiny_libvirt_ip string
-	var tiny_libvirt_key string
+	server := redfish.New()
 
-	flag.StringVar(&tiny_sushy_port, "port", "8000", "port to listen")
-	flag.StringVar(&tiny_libvirt_user, "user", "root", "user for libvirt connection")
-	flag.StringVar(&tiny_libvirt_ip, "ip", "127.0.0.1", "ip of libvirt server")
-	flag.StringVar(&tiny_libvirt_key, "keyfile", "~/.ssh/id_rsa", "path to ssh key for libvirt server")
+	flag.StringVar(&server.TinySushyPort, "port", "8000", "port to listen")
+	flag.StringVar(&server.TinyOobUser, "user", "root", "user for libvirt connection")
+	flag.StringVar(&server.TinyOobIP, "ip", "127.0.0.1", "ip of libvirt server")
+	flag.StringVar(&server.TinyOobKey, "keyfile", "~/.ssh/id_rsa", "path to ssh key for libvirt server")
 
 	flag.Parse()
 
-	server := redfish.New()
-	server.Start(tiny_sushy_port, tiny_libvirt_user, tiny_libvirt_ip, tiny_libvirt_key)
+	server.Start()
 }

--- a/internal/dummydriver/dummydriver.go
+++ b/internal/dummydriver/dummydriver.go
@@ -1,0 +1,18 @@
+package dummydriver
+
+//Sample scalfolding for a driver
+
+type DummyDriverFacade struct {
+	dummy string
+}
+
+func (l *DummyDriverFacade) NewConnection(systemID string, tinyOobUser string, tinyOobIP string, tinyOobKey string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (l *DummyDriverFacade) CloseConnection() error             { return nil }
+func (l *DummyDriverFacade) BootFromDevice(device string) error { return nil }
+func (l *DummyDriverFacade) MountISO(isoUrl string) error       { return nil }
+func (l *DummyDriverFacade) EjectISO() error                    { return nil }
+func (l *DummyDriverFacade) PowerOn() error                     { return nil }
+func (l *DummyDriverFacade) PowerOff() error                    { return nil }
+func (l *DummyDriverFacade) Reboot() error                      { return nil }

--- a/internal/execdriver/execdriver.go
+++ b/internal/execdriver/execdriver.go
@@ -1,0 +1,38 @@
+package execdriver
+
+import "strconv"
+
+type ExecDriverFacade struct {
+	dummy string
+}
+
+func (exec *ExecDriverFacade) NewConnection(systemID string, tinyOobUser string, tinyOobIP string, tinyOobKey string) (map[string]string, error) {
+	systemMap := map[string]string{
+		"Identity":         "id-6e162f250552",
+		"Name":             "dummy",
+		"UUID":             "4ef0b933-5439-42bd-bc97-6e162f250552",
+		"PowerState":       "On",
+		"BootSourceTarget": "cdrom",
+		"BootSourceMode":   exec.getBootSourceMode(),
+		"TotalCpus":        strconv.FormatUint(uint64(exec.getTotalCpus()), 10),   //uint
+		"TotalMemoryGB":    strconv.FormatUint(uint64(exec.getTotalMemory()), 10), //uint64
+		"IndicatorLed":     "Lit",
+		"Username":         "admin",
+		"Password":         "password",
+	}
+
+	return systemMap, nil
+}
+
+//Not implemented
+func (exec *ExecDriverFacade) CloseConnection() error             { return nil }
+func (exec *ExecDriverFacade) BootFromDevice(device string) error { return nil }
+func (exec *ExecDriverFacade) MountISO(isoUrl string) error       { return nil }
+func (exec *ExecDriverFacade) EjectISO() error                    { return nil }
+func (exec *ExecDriverFacade) PowerOn() error                     { return nil }
+func (exec *ExecDriverFacade) PowerOff() error                    { return nil }
+func (exec *ExecDriverFacade) Reboot() error                      { return nil }
+
+func (exec *ExecDriverFacade) getBootSourceMode() string { return "None" }
+func (exec *ExecDriverFacade) getTotalCpus() uint        { return 0 }
+func (exec *ExecDriverFacade) getTotalMemory() uint64    { return 0 }

--- a/internal/libvirtdriver/libvirtdriver.go
+++ b/internal/libvirtdriver/libvirtdriver.go
@@ -1,4 +1,4 @@
-package redfish
+package libvirtdriver
 
 import (
 	"strconv"
@@ -50,8 +50,8 @@ type libvirtDomainFacade struct {
 	domain *libvirt.Domain
 }
 
-func Uri(user string, ip string, keyfilePath string) (string, error) {
-	// default URI: "qemu+ssh://root@192.168.111.1/system?&keyfile=~/.ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
+func uri(user string, ip string, keyfilePath string) (string, error) {
+	// default u: "qemu+ssh://root@192.168.111.1/system?&keyfile=~/.ssh/id_rsa_virt_power&no_verify=1&no_tty=1"
 	var lvUrl string
 
 	if user == "" {
@@ -76,22 +76,23 @@ func isValidUUID(u string) bool {
 	return err == nil
 }
 
-func newLibvirtDomain(UUID string) *libvirtDomainFacade {
+//Function exposed to
+func NewLibvirtDomain(systemID string, libvirtUser string, libvirtIP string, libvirtKey string) *libvirtDomainFacade {
 	var dom *libvirt.Domain
 
-	url, _ := Uri(TINY_LIBVIRT_USER, TINY_LIBVIRT_IP, TINY_LIBVIRT_KEY)
+	url, _ := uri(libvirtUser, libvirtIP, libvirtKey)
 	conn, err := libvirt.NewConnect(url)
 	if err != nil {
 		panic(err)
 	}
 
-	if isValidUUID(UUID) {
-		dom, err = conn.LookupDomainByUUIDString(UUID)
+	if isValidUUID(systemID) {
+		dom, err = conn.LookupDomainByUUIDString(systemID)
 		if err != nil {
 			panic(err)
 		}
 	} else {
-		dom, err = conn.LookupDomainByName(UUID)
+		dom, err = conn.LookupDomainByName(systemID)
 		if err != nil {
 			panic(err)
 		}
@@ -105,11 +106,11 @@ func newLibvirtDomain(UUID string) *libvirtDomainFacade {
 	return facade
 }
 
-func (l *libvirtDomainFacade) close() {
+func (l *libvirtDomainFacade) Close() {
 	l.conn.Close()
 }
 
-func (l *libvirtDomainFacade) getName() string {
+func (l *libvirtDomainFacade) GetName() string {
 	name, err := l.domain.GetName()
 	if err != nil {
 		panic(err)
@@ -117,7 +118,7 @@ func (l *libvirtDomainFacade) getName() string {
 	return name
 }
 
-func (l *libvirtDomainFacade) getUUID() string {
+func (l *libvirtDomainFacade) GetUUID() string {
 	uuidBytes, err := l.domain.GetUUID()
 	if err != nil {
 		panic(err)
@@ -126,7 +127,7 @@ func (l *libvirtDomainFacade) getUUID() string {
 	return uuidstr.String()
 }
 
-func (l *libvirtDomainFacade) getPowerState() string {
+func (l *libvirtDomainFacade) GetPowerState() string {
 	state := "Off"
 	active, err := l.domain.IsActive()
 	if err != nil {
@@ -140,7 +141,7 @@ func (l *libvirtDomainFacade) getPowerState() string {
 	return state
 }
 
-func (l *libvirtDomainFacade) getBootSourceTarget() string {
+func (l *libvirtDomainFacade) GetBootSourceTarget() string {
 
 	xmlDesc, err := l.domain.GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE)
 	if err != nil {
@@ -199,7 +200,7 @@ func (l *libvirtDomainFacade) getBootSourceTarget() string {
 	return target
 }
 
-func (l *libvirtDomainFacade) getBootSourceMode() string {
+func (l *libvirtDomainFacade) GetBootSourceMode() string {
 	mode := "None"
 
 	xmlDesc, err := l.domain.GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE)
@@ -217,7 +218,7 @@ func (l *libvirtDomainFacade) getBootSourceMode() string {
 	return mode
 }
 
-func (l *libvirtDomainFacade) getTotalCpus() uint {
+func (l *libvirtDomainFacade) GetTotalCpus() uint {
 	maxCpus, err := l.domain.GetMaxVcpus()
 	if err != nil {
 		panic(err)
@@ -225,7 +226,7 @@ func (l *libvirtDomainFacade) getTotalCpus() uint {
 	return maxCpus
 }
 
-func (l *libvirtDomainFacade) getTotalMemory() uint64 {
+func (l *libvirtDomainFacade) GetTotalMemory() uint64 {
 	maxMem, err := l.domain.GetMaxMemory()
 	if err != nil {
 		panic(err)

--- a/internal/litehost/litehost.go
+++ b/internal/litehost/litehost.go
@@ -1,20 +1,51 @@
 package litehost
 
-// NOTE: INITIAL SALFOLDING FOR INTERFACE
+import (
+	"log"
 
-type liteHost interface {
-	bootFromDevice(device string) error
-	mountISO(isoUrl string) error
-	ejectISO() error
-	powerOn() error
-	powerOff() error
-	reboot() error
+	"github.com/andfasano/tiny-sushy-tools/internal/dummydriver"
+	"github.com/andfasano/tiny-sushy-tools/internal/execdriver"
+	"github.com/andfasano/tiny-sushy-tools/internal/libvirtdriver"
+)
+
+type LiteHost interface {
+	BootFromDevice(device string) error
+	MountISO(isoUrl string) error
+	EjectISO() error
+	PowerOn() error
+	PowerOff() error
+	Reboot() error
+	NewConnection(systemID string, tinyOobUser string, tinyOobIP string, tinyOobKey string) (map[string]string, error)
+	CloseConnection() error
 }
 
-func StartLiteHost(lh liteHost) error {
-	//make sure host is off and no ISO is mounted to it
-	lh.powerOff()
-	lh.ejectISO()
+type DriverLoader struct {
+	liteHostAttributes map[string]string
+}
+
+//make sure host is off and no ISO is mounted to it
+func (dl *DriverLoader) StartLiteHost(driver string, systemID string, tinyOobUser string, tinyOobIP string, tinyOobKey string) error {
+	var lh LiteHost
+
+	if driver == "libvirt" {
+		lh = &libvirtdriver.LibvirtDomainFacade{}
+	} else if driver == "execdriver" {
+		lh = &execdriver.ExecDriverFacade{}
+	} else if driver == "dummydriver" {
+		lh = &dummydriver.DummyDriverFacade{}
+	} else {
+		log.Println("Invalid driver ", driver)
+		log.Fatal("Invalid driver")
+	}
+
+	dl.liteHostAttributes, _ = lh.NewConnection(systemID, tinyOobUser, tinyOobIP, tinyOobKey)
 
 	return nil
+}
+
+func (dl *DriverLoader) LiteHostAttribute(key string, defaultValue string) string {
+	if val, ok := dl.liteHostAttributes[key]; ok {
+		return val
+	}
+	return defaultValue
 }

--- a/internal/litehost/litehost.go
+++ b/internal/litehost/litehost.go
@@ -1,0 +1,20 @@
+package litehost
+
+// NOTE: INITIAL SALFOLDING FOR INTERFACE
+
+type liteHost interface {
+	bootFromDevice(device string) error
+	mountISO(isoUrl string) error
+	ejectISO() error
+	powerOn() error
+	powerOff() error
+	reboot() error
+}
+
+func StartLiteHost(lh liteHost) error {
+	//make sure host is off and no ISO is mounted to it
+	lh.powerOff()
+	lh.ejectISO()
+
+	return nil
+}

--- a/internal/redfish/redfish.go
+++ b/internal/redfish/redfish.go
@@ -18,10 +18,11 @@ type Server struct {
 
 	systems map[string]*system
 
-	TinySushyPort string
-	TinyOobUser   string
-	TinyOobIP     string
-	TinyOobKey    string
+	TinySushyPort   string
+	TinySushyDriver string
+	TinyOobUser     string
+	TinyOobIP       string
+	TinyOobKey      string
 }
 
 //New creates a new instance of the Redfish server
@@ -212,7 +213,8 @@ func (rf *Server) handleSystemsByID(w http.ResponseWriter, r *http.Request) {
 
 		s, ok := rf.systems[systemID]
 		if ok == false {
-			s = newSystem(systemID, rf)
+			s = new(system)
+			s.newSystem(systemID, rf)
 			rf.systems[systemID] = s
 		}
 

--- a/internal/redfish/system.go
+++ b/internal/redfish/system.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"strings"
 	"text/template"
+
+	"github.com/andfasano/tiny-sushy-tools/internal/libvirtdriver"
 )
 
 type system struct {
@@ -21,27 +23,30 @@ type system struct {
 	Password string
 }
 
-func newSystem(UUID string) *system {
+func newSystem(systemID string, rf *Server) *system {
 	s := &system{
-		UUID:             UUID,
-		Identity:         UUID,
+		Identity:         systemID,
+		Name:             "",
+		UUID:             "",
 		PowerState:       "Off",
-		IndicatorLed:     "Lit",
 		BootSourceTarget: "None",
 		BootSourceMode:   "None",
+		TotalCpus:        0,
+		TotalMemoryGB:    0,
+		IndicatorLed:     "Lit",
 		Username:         "admin",
 		Password:         "password",
 	}
 
-	lv := newLibvirtDomain(UUID)
+	lv := libvirtdriver.NewLibvirtDomain(systemID, rf.TinyOobUser, rf.TinyOobIP, rf.TinyOobKey)
 
-	s.UUID = lv.getUUID()
-	s.Name = lv.getName()
-	s.PowerState = lv.getPowerState()
-	s.BootSourceTarget = lv.getBootSourceTarget()
-	s.BootSourceMode = lv.getBootSourceMode()
-	s.TotalCpus = lv.getTotalCpus()
-	s.TotalMemoryGB = lv.getTotalMemory()
+	s.UUID = lv.GetUUID()
+	s.Name = lv.GetName()
+	s.PowerState = lv.GetPowerState()
+	s.BootSourceTarget = lv.GetBootSourceTarget()
+	s.BootSourceMode = lv.GetBootSourceMode()
+	s.TotalCpus = lv.GetTotalCpus()
+	s.TotalMemoryGB = lv.GetTotalMemory()
 
 	return s
 }


### PR DESCRIPTION
- Refactored with multiple drivers
- Adding scaffolding for `execdriver` and a reference `dummydriver`
- moving attributes parsing from system.go to litehost.go for decoupling dependencies. Now only litehost.go needs to import drivers
- `redfish` package is now completely decoupled from backend drivers
- Updating README.md with steps for building packages
- Refactored code to remove global environmental variables
- Extended Server struct to include information that was previously global env vars
- Refactored main to use new Server object
- A lot of additional verifications added to Start
- Created new stand alone package `libvirtdriver` as first step for decoupling `redfish` package from libvirt